### PR TITLE
Convert Ripple Epoch to Unix Epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A JSON object is returned with the following keys:
 - `error`: Empty string if no error, or error details.
 - `http_code`: Returns the http code as an integer, if it is available.
 - `public_validation_keys`: Returns a list of parsed keys, or an empty list if an error is encountered.
-- `expiration`: UNL expiration date.
+- `expiration`: UNL expiration date (Unix Epoch).
 
 ## Limitations and Future Development
 The script does not verify the signature for the UNL manifest. Hopefully this will be available in a future version.

--- a/parse_unl.py
+++ b/parse_unl.py
@@ -43,6 +43,12 @@ def unl_parser(address):
     try:
         blob = json.loads(b64decode(unl.json()['blob']).decode('utf-8'))
         validators = blob['validators']
+        '''
+        Convert Ripple Epoch to Unix Epoch
+        Reference : https://xrpl.org/basic-data-types.html
+        '''
+        keys['expiration'] = blob['expiration'] + 946684800
+
         keys['expiration'] = blob['expiration']
     except json.decoder.JSONDecodeError:
         keys['error'] = "Invalid or malformed manifest."

--- a/parse_unl.py
+++ b/parse_unl.py
@@ -49,7 +49,6 @@ def unl_parser(address):
         '''
         keys['expiration'] = blob['expiration'] + 946684800
 
-        keys['expiration'] = blob['expiration']
     except json.decoder.JSONDecodeError:
         keys['error'] = "Invalid or malformed manifest."
         return json.dumps(keys)


### PR DESCRIPTION
The Ripple Epoch is 946684800 seconds after the Unix Epoch. For easier examination, the value in the blob has been converted to Unix Epoch.

https://xrpl.org/basic-data-types.html